### PR TITLE
Add Support for Elasticache Serverless

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ which generates a .jar file, which you can then use to run you java application.
 $ java -cp target/ElastiCacheIAMAuthDemoApp-1.0-SNAPSHOT.jar \
 	com.amazon.elasticache.IAMAuthTokenGeneratorApp \
 	--region us-east-1 \
-	--replication-group-id iam-test-rg-01 \
+	--cache-name iam-test-rg-01 \
 	--user-id iam-test-user-01
 ```
 
@@ -58,11 +58,13 @@ NOTE:
 $ java -jar target/ElastiCacheIAMAuthDemoApp-1.0-SNAPSHOT.jar \
 	--redis-host <host> \
 	--region us-east-1 \
-	--replication-group-id iam-test-rg-01 \
+	--cache-name iam-test-rg-01 \
 	--user-id iam-test-user-01 \
 	--tls
 ```
 
 For cluster-mode enabled replication groups, please add the `--cluster-mode` flag.
+
+For serverless caches, please add the `--serverless` flag.
 
 The demo app creates a new connection to the host using the IAM user identity and generates an IAM authentication token.

--- a/src/main/java/com/amazon/elasticache/IAMAuthDemoApp.java
+++ b/src/main/java/com/amazon/elasticache/IAMAuthDemoApp.java
@@ -36,14 +36,17 @@ public class IAMAuthDemoApp {
     @Parameter(names = {"--cluster-mode"})
     private boolean clusterModeEnabled = false;
 
+    @Parameter(names = { "--serverless" })
+    private boolean serverlessEnabled = false;
+
     @Parameter(names = {"--user-id"})
     private String userId;
 
     @Parameter(names = {"--password"})
     private String password;
 
-    @Parameter(names = {"--replication-group-id"})
-    private String replicationGroupId;
+    @Parameter(names = {"--cache-name"})
+    private String cacheName;
 
     @Parameter(names = {"--region"})
     private String region = "us-east-1";
@@ -140,8 +143,8 @@ public class IAMAuthDemoApp {
             return new RedisStaticCredentialsProvider(userId, password);
         }
 
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(replicationGroupId),
-            "replicationGroupId cannot be be null or emtpy");
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(cacheName),
+            "cacheName cannot be be null or emtpy");
 
 
         // Create a default AWS Credentials provider.
@@ -151,7 +154,8 @@ public class IAMAuthDemoApp {
 
         // Create an IAM Auth Token request. Once this request is signed it can be used as an
         // IAM Auth token for Elasticache Redis.
-        IAMAuthTokenRequest iamAuthTokenRequest = new IAMAuthTokenRequest(userId, replicationGroupId, region);
+        IAMAuthTokenRequest iamAuthTokenRequest = new IAMAuthTokenRequest(userId, cacheName, region,
+                serverlessEnabled);
 
         // Create a Redis credentials provider using IAM credentials.
         return new RedisIAMAuthCredentialsProvider(

--- a/src/main/java/com/amazon/elasticache/IAMAuthTokenGeneratorApp.java
+++ b/src/main/java/com/amazon/elasticache/IAMAuthTokenGeneratorApp.java
@@ -18,8 +18,11 @@ public class IAMAuthTokenGeneratorApp {
     @Parameter(names = {"--user-id"})
     private String userId;
 
-    @Parameter(names = {"--replication-group-id"})
-    private String replicationGroupId;
+    @Parameter(names = {"--cache-name"})
+    private String cacheName;
+
+    @Parameter(names = { "--serverless" })
+    private Boolean serverlessEnabled;
 
     @Parameter(names = {"--region"})
     private String region = "us-east-1";
@@ -40,8 +43,8 @@ public class IAMAuthTokenGeneratorApp {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(userId),
             "userId cannot be be null or emtpy");
 
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(replicationGroupId),
-            "replicationGroupId cannot be be null or emtpy");
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(cacheName),
+            "cacheName cannot be be null or emtpy");
 
         // Create a default AWS Credentials provider.
         // This will look for AWS credentials as defined in the doc.
@@ -50,7 +53,8 @@ public class IAMAuthTokenGeneratorApp {
 
         // Create an IAM Auth Token request and signed it using the AWS credentials.
         // The pre-signed request URL is used as an IAM Auth token for Elasticache Redis.
-        IAMAuthTokenRequest iamAuthTokenRequest = new IAMAuthTokenRequest(userId, replicationGroupId, region);
+        IAMAuthTokenRequest iamAuthTokenRequest = new IAMAuthTokenRequest(userId, cacheName, region,
+                serverlessEnabled);
         String iamAuthToken = iamAuthTokenRequest.toSignedRequestUri(awsCredentialsProvider.resolveCredentials());
 
         System.out.println(iamAuthToken);


### PR DESCRIPTION
## Description of changes:

Added support for serverless caches and renamed the `replication-group-id` parameter to `cache-name`.

Serverless caches require an additional `ResourceType=ServerlessCache` query parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
