### PR TITLE
This version replaces the deprecated Aws4Signer with AwsV4HttpSigner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,19 @@
     <dependency>
       <groupId>io.lettuce</groupId>
       <artifactId>lettuce-core</artifactId>
-      <version>6.2.1.RELEASE</version>
+      <version>6.2.2.RELEASE</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/aws-sdk-java -->
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-sdk-java</artifactId>
-      <version>2.20.22</version>
+      <version>2.29.23</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/http-auth-aws -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>http-auth-aws</artifactId>
+      <version>2.29.23</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/amazon/elasticache/IAMAuthDemoApp.java
+++ b/src/main/java/com/amazon/elasticache/IAMAuthDemoApp.java
@@ -2,17 +2,32 @@ package com.amazon.elasticache;
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+/* Show the arn of the Credentials if needed
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
+*/
+
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.Uninterruptibles;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisCredentialsProvider;
+import io.lettuce.core.RedisException;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.cluster.ClusterClientOptions;
+import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.models.partitions.RedisClusterNode;
+
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -69,6 +84,9 @@ public class IAMAuthDemoApp {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(redisHost),
             "redisHost cannot be null or emtpy");
 
+        // Set DNS cache TTL
+        java.security.Security.setProperty("networkaddress.cache.ttl", "10");
+        
         // Construct Redis URL with credentials provider.
         RedisURI redisURI = RedisURI.builder()
             .withHost(redisHost)
@@ -85,50 +103,80 @@ public class IAMAuthDemoApp {
     }
 
     private void runRedisExample(RedisURI redisURI) {
+        boolean done = false;
         // Create a new Lettuce Redis client
         RedisClient redisClient =  RedisClient.create(redisURI);
+        redisClient.setOptions(ClientOptions.builder().autoReconnect(true)
+            .pingBeforeActivateConnection(true)
+            .build());
+        StatefulRedisConnection<String, String> connection = null;
+        connection = redisClient.connect();
 
         // Run until demo app is stopped
-        while (true) {
+        while (!done) {
 
             // Connect a new client and perform a read command.
             // This will automatically fetch an IAM Auth token from the credentials provider,
             // or reuse a cached token for `authTokenTimeoutSeconds`.
-            StatefulRedisConnection<String, String> connection = redisClient.connect();
-            connection.sync().get(getRandKey());
+            try {
+                connection.sync().get(getRandKey());
 
-            numConnections += 1;
-            System.out.println("=> Successful connections: " + numConnections);
+                numConnections += 1;
+                System.out.println("=> Successful sent commands: " + numConnections);
+            } catch(RedisException e) {
+                e.printStackTrace();
+            }
 
             // Sleep for a bit
             Uninterruptibles.sleepUninterruptibly(connectSleepTimeSeconds, TimeUnit.SECONDS);
-
-            // Close Redis client connection
-            connection.close();
         }
+
+        // Close Redis client connection
+        if(connection != null) connection.close();
     }
 
     private void runRedisClusterExample(RedisURI redisURI) {
+        boolean done = false;
         RedisClusterClient redisClusterClient = RedisClusterClient.create(redisURI);
+        ClusterTopologyRefreshOptions topologyOptions = ClusterTopologyRefreshOptions.builder()
+            .enableAllAdaptiveRefreshTriggers()
+            .enablePeriodicRefresh()
+            .dynamicRefreshSources(true)
+            .build();
+        redisClusterClient.setOptions(ClusterClientOptions.builder()
+        .topologyRefreshOptions(topologyOptions)
+        .autoReconnect(true)
+        .pingBeforeActivateConnection(true)
+        .nodeFilter(it -> 
+            ! (it.is(RedisClusterNode.NodeFlag.FAIL) 
+            || it.is(RedisClusterNode.NodeFlag.EVENTUAL_FAIL) 
+            || it.is(RedisClusterNode.NodeFlag.NOADDR)))
+        .build());
+        StatefulRedisClusterConnection<String, String> connection = null;
+        connection = redisClusterClient.connect();
+        connection.setReadFrom(ReadFrom.ANY);
 
         // Run until demo app is stopped
-        while (true) {
+        while (!done) {
 
             // Connect a new client and perform a read command.
             // This will automatically fetch an IAM Auth token from the credentials provider,
             // or reuse a cached token for `authTokenTimeoutSeconds`.
-            StatefulRedisClusterConnection<String, String> connection = redisClusterClient.connect();
-            connection.sync().get(getRandKey());
+            try {
+                connection.sync().get(getRandKey());
 
-            numConnections += 1;
-            System.out.println("=> Successful connections: " + numConnections);
+                numConnections += 1;
+                System.out.println("=> Successful sent commands: " + numConnections);
+            } catch(RedisException e) {
+                e.printStackTrace();
+            }
 
             // Sleep for a bit
             Uninterruptibles.sleepUninterruptibly(connectSleepTimeSeconds, TimeUnit.SECONDS);
-
-            // Close Redis client connection
-            connection.close();
         }
+
+        // Close Redis client connection
+        if(connection != null) connection.close();
     }
 
     private RedisCredentialsProvider getCredentialsProvider() {
@@ -148,6 +196,19 @@ public class IAMAuthDemoApp {
         // This will look for AWS credentials as defined in the doc.
         // https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html
         AwsCredentialsProvider awsCredentialsProvider = DefaultCredentialsProvider.create();
+
+        /* Show the arn of the Credentials if needed
+        // Show the current role of the Credentials
+        StsClient stsClient = StsClient.builder()
+                .credentialsProvider(awsCredentialsProvider)
+                .region(Region.AWS_GLOBAL)  // STS is a global service
+                .build();
+        GetCallerIdentityRequest request = GetCallerIdentityRequest.builder().build();
+        GetCallerIdentityResponse response = stsClient.getCallerIdentity(request);
+        String arn = response.arn();
+        System.out.println("The role of the Credential is: " + arn);
+        stsClient.close();
+        */
 
         // Create an IAM Auth Token request. Once this request is signed it can be used as an
         // IAM Auth token for Elasticache Redis.


### PR DESCRIPTION
This version replaces the deprecated Aws4Signer with AwsV4HttpSigner in the new version of the AWS SDK. It uses long-lived connections in the main program and modifies the connection configuration to enable automatic reconnection when an Elasticache Redis cluster fails over or when an IAM connection is disconnected.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
