### PR TITLE
Modify the dependency library versions to allow test to compile and run in a Java 8 environment

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'corretto'
           cache: maven
       - name: Run Maven verify

--- a/pom.xml
+++ b/pom.xml
@@ -54,13 +54,13 @@
     <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
-        <version>5.13.4</version>
+        <version>5.8.2</version>
         <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>5.18.0</version>
+      <artifactId>mockito-inline</artifactId>
+      <version>4.11.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Modify the dependency library versions to allow test to compile and run in a Java 8 environment.
*Issue #, if available:*

*Description of changes:*
Since the README.md explicitly states that this Demo uses Java 8, the test dependency libraries have been modified to versions that support Java 8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
